### PR TITLE
Add some "smarter" error handling

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -35,18 +35,10 @@ module.exports = (method, data, callback) => {
         if(err) return callback(err);
         try {
             if(body.length === 0) return callback({ statusCode: res.statusCode });
-            try {
-                let response = JSON.parse(body);
-                callback(null,response);
-            } catch (e) {
-                if ([200,500].includes(res.statusCode)) {
-                    callback({ statusCode: res.statusCode }, {error: "Invalid JSON", status: res.statusCode});
-                }  else {
-                    throw e;
-                }
-            }
+            callback(null,JSON.parse(body));
         }
         catch(err) {
+            err.statusCode = res.statusCode;
             callback(err);
         }
     });

--- a/lib/request.js
+++ b/lib/request.js
@@ -35,8 +35,18 @@ module.exports = (method, data, callback) => {
         if(err) return callback(err);
         try {
             if(body.length === 0) return callback({ statusCode: res.statusCode });
-            let response = JSON.parse(body);
-            callback(null, response);
+            try {
+                let response = JSON.parse(body);
+                callback(null,response);
+            } catch (e) {
+                if (res.statusCode !== 200) {
+                    console.error("Error parsing Twitch API JSON Response (Returning without body for "+res.statusCode+"):\n"+e.stack);
+                    callback(null, {error: "Invalid JSON", status: res.statusCode});
+                }  else {
+                    console.error("Error parsing Twitch API JSON Response (Rejecting for "+res.statusCode+"):\n"+e.stack);
+                    throw e;
+                }
+            }
         }
         catch(err) {
             callback(err);

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,7 +40,7 @@ module.exports = (method, data, callback) => {
                 callback(null,response);
             } catch (e) {
                 if ([200,500].includes(res.statusCode)) {
-                    callback(null, {error: "Invalid JSON", status: res.statusCode});
+                    callback(null, {error: "Invalid JSON", statusCode: res.statusCode});
                 }  else {
                     throw e;
                 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -35,7 +35,7 @@ module.exports = (method, data, callback) => {
         if(err) return callback(err);
         try {
             if(body.length === 0) return callback({ statusCode: res.statusCode });
-            callback(null,JSON.parse(body));
+            callback(null, JSON.parse(body));
         }
         catch(err) {
             err.statusCode = res.statusCode;

--- a/lib/request.js
+++ b/lib/request.js
@@ -39,7 +39,7 @@ module.exports = (method, data, callback) => {
                 let response = JSON.parse(body);
                 callback(null,response);
             } catch (e) {
-                if (res.statusCode !== 200) {
+                if ([200,500].includes(res.statusCode)) {
                     console.error("Error parsing Twitch API JSON Response (Returning without body for "+res.statusCode+"):\n"+e.stack);
                     callback(null, {error: "Invalid JSON", status: res.statusCode});
                 }  else {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,7 +40,7 @@ module.exports = (method, data, callback) => {
                 callback(null,response);
             } catch (e) {
                 if ([200,500].includes(res.statusCode)) {
-                    callback(null, {error: "Invalid JSON", statusCode: res.statusCode});
+                    callback({ statusCode: res.statusCode }, {error: "Invalid JSON", status: res.statusCode});
                 }  else {
                     throw e;
                 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,10 +40,8 @@ module.exports = (method, data, callback) => {
                 callback(null,response);
             } catch (e) {
                 if ([200,500].includes(res.statusCode)) {
-                    console.error("Error parsing Twitch API JSON Response (Returning without body for "+res.statusCode+"):\n"+e.stack);
                     callback(null, {error: "Invalid JSON", status: res.statusCode});
                 }  else {
-                    console.error("Error parsing Twitch API JSON Response (Rejecting for "+res.statusCode+"):\n"+e.stack);
                     throw e;
                 }
             }


### PR DESCRIPTION
I've ran into a situation where the twitch API returns garbage on the body instead of JSON throwing an error back up to my application. This was my dirty fix to let my program continue with the error response.

This code will still throw an error for 200s and 500s that can't be parsed but will log an error to console for special status codes like 422 on checkSubs